### PR TITLE
Update podspec.md

### DIFF
--- a/content/docs/reference/podspec.md
+++ b/content/docs/reference/podspec.md
@@ -224,7 +224,16 @@ localization:
 ```yaml
 # /content/collectiion/document.yaml
 foo: base
-foo@locales.group1: tagged for de, fr, or it locales.
+foo@locale.group1: tagged for de, fr, or it locales.
+```
+
+If there are already locales being used:
+
+```yaml
+# /content/collectiion/document.yaml
+foo: base
+foo@:en_US|en_UK: normal localization usage.
+foo@locale.group1: tagged for de, fr, or it locales.
 ```
 
 ### preprocessors


### PR DESCRIPTION
Just checked thoroughly and it does work correctly with "locale" in singular, sorry for that.
But for some reason it does not work if used like:

```
foo@en_US|locale.group1: ~
```

So we managed to make it work like this, putting it below the existing:
```
foo@en_US: ~
foo@locale.group1: ~
```