### PR TITLE
Better clarify which file the path update applies to

### DIFF
--- a/content/codelab/5.md
+++ b/content/codelab/5.md
@@ -48,7 +48,7 @@ Why do some fields end with @? This indicates that they are tagged for message e
 
 The ability to easily change URLs (both during and after the development phase of projects) is an important feature and also a good example of the "configuration, not code" philosophy. URLs are defined by a mix of definitions in `podspec.yaml`, a collection's `_blueprint.yaml`, and each individual content document.
 
-Currently, the "The Team" page inherits its URL from its blueprint (`/content/pages/_blueprint.yaml`). Let's override the URL for this page. Add the following line to the top of the document's YAML front matter.
+Currently, the "The Team" page inherits its URL from its blueprint (`/content/pages/_blueprint.yaml`). Let's override the URL for this page. In `team.md`, add the following line to the top of the document's YAML front matter.
 
 ```yaml
 $path: /custom-team-path/


### PR DESCRIPTION
Going through the Codelab in grow.io, I ran into a sentence on the "Working with content" page that in my mind could benefit from being even clearer on which file an edit applies to.

Since `/content/pages/_blueprint.yaml` is mentioned in the previous sentence, I was first confused and though that was the file I was suppose to edit. After reading the paragraph over a few more times, I realized the changes applied to `team.md`.